### PR TITLE
add check for token ownership by theBarn in refund

### DIFF
--- a/test/Market.t.sol
+++ b/test/Market.t.sol
@@ -618,7 +618,7 @@ contract MarketTest is Test {
         vm.prank(user1);
         market.startAuctionERC721{value: 0.05 ether}(address(mock721), tokenIds);
 
-        vm.expectRevert(bytes4(keccak256("AuctionActive()")));
+        vm.expectRevert(bytes4(keccak256("SettlementPeriodNotExpired()")));
         market.abandon(1);
     }
 
@@ -628,7 +628,7 @@ contract MarketTest is Test {
 
         skip(60 * 60 * 24 * 7 + 1);
 
-        vm.expectRevert(bytes4(keccak256("SettlementPeriodActive()")));
+        vm.expectRevert(bytes4(keccak256("SettlementPeriodNotExpired()")));
         market.abandon(1);
     }
 


### PR DESCRIPTION
requires theBarn to not only have approvals set but also own the tokens to prevent the winning bidder from claiming a full refund during the settlement period

caches bid/bidder/endtime values in claim/refund/abandon for gas efficiency

Skip check for auction active in abandon and only check that settlement period has not expired (if settlement hasn't expired, auction isn't over either), change revert to SettlementPeriodNotExpired

emit Refund event instead of Claimed in refund function