### PR TITLE
[MED] The highest bidder has an advantage at block.timestamp = auction.endTime

### DIFF
--- a/src/Auctions.sol
+++ b/src/Auctions.sol
@@ -17,6 +17,7 @@ import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import "solady/src/auth/Ownable.sol";
 import "./IBidTicket.sol";
 
+//@audit No inactive default status
 enum Status {
     Active,
     Claimed,
@@ -123,6 +124,7 @@ contract Auctions is Ownable {
         address tokenAddress,
         uint256[] calldata tokenIds
     ) external payable {
+        //@audit minStartingBid per token is it?
         if (startingBid < minStartingBid) revert StartPriceTooLow();
         if (tokenIds.length == 0) revert InvalidLengthOfTokenIds();
         if (tokenIds.length > maxTokens) revert MaxTokensPerTxReached();
@@ -136,10 +138,12 @@ contract Auctions is Ownable {
         auction.endTime = uint64(block.timestamp + auctionDuration);
         auction.highestBidder = msg.sender;
         auction.highestBid = startingBid;
+        //@audit-issue tokenCount can be max 256 but the check is not present in the maxTokens check
         auction.tokenCount = uint8(tokenIds.length);
         auction.bidderCount = 1;
         auction.bidDelta = startingBid;
 
+        //@audit auction.tokenIds is not set in the previous state and this tokenMap makes no sense here
         mapping(uint256 => uint256) storage tokenMap = auction.tokenIds;
 
         for (uint256 i; i < tokenIds.length; ++i) {
@@ -152,9 +156,12 @@ contract Auctions is Ownable {
 
         emit Started(msg.sender, tokenAddress, tokenIds);
         
+        //@audit It should be bidTicketCostStart * tokenIds.length()
         bidTicket.burn(msg.sender, bidTicketTokenId, bidTicketCostStart);
 
         _validateAuctionTokensERC721(tokenAddress, tokenIds);
+
+        //@audit Doesn't add to auction.bidders
     }
 
     /**
@@ -180,12 +187,14 @@ contract Auctions is Ownable {
         _processPayment(startingBid);
 
         Auction storage auction = auctions[nextAuctionId];
-
+        
+        //@audit Doesn't check if the auction is already present or not
         auction.auctionType = AUCTION_TYPE_ERC1155;
         auction.tokenAddress = tokenAddress;
         auction.endTime = uint64(block.timestamp + auctionDuration);
         auction.highestBidder = msg.sender;
         auction.highestBid = startingBid;
+        //@audit token count for ERC1155 is incorrect
         auction.tokenCount = uint8(tokenIds.length);
         auction.bidderCount = 1;
         auction.bidDelta = startingBid;
@@ -220,10 +229,12 @@ contract Auctions is Ownable {
         Auction storage auction = auctions[auctionId];
 
         if (auction.status != Status.Active) revert InvalidStatus();
+        //@audit A user can call wit 2 addresses
         if (auction.highestBidder == msg.sender) revert IsHighestBidder();
         if (bidAmount < auction.highestBid + minBidIncrement) revert BidTooLow();
         if (block.timestamp > auction.endTime) revert AuctionEnded();
 
+        //@audit A malicious user will not the auction end because of this
         if (block.timestamp >= auction.endTime - antiSnipeDuration) {
             auction.endTime += uint64(antiSnipeDuration);
         }
@@ -238,6 +249,7 @@ contract Auctions is Ownable {
             balances[prevHighestBidder] += prevHighestBid;
 
             // Add new bidder to the bidders list
+            //@audit What is this rewards check?
             if (auction.rewards[prevHighestBidder] == 0) {
                 auction.bidders[auction.bidderCount - 1] = prevHighestBidder;
                 ++auction.bidderCount;
@@ -256,6 +268,7 @@ contract Auctions is Ownable {
 
         emit NewBid(auctionId, msg.sender, bidAmount);
 
+        //@audit Why burn just 1 token?
         bidTicket.burn(msg.sender, bidTicketTokenId, bidTicketCostBid);
     }
 
@@ -266,10 +279,12 @@ contract Auctions is Ownable {
      *
      */
 
+    //@audit Both claim, refund & bid can be called at block.timestamp = auction.endTime
     function claim(uint256 auctionId) external {
         Auction storage auction = auctions[auctionId];
 
         if (auction.status != Status.Active) revert InvalidStatus();
+        //@audit should be <=
         if (block.timestamp < auction.endTime) revert AuctionNotEnded();
         if (msg.sender != auction.highestBidder && msg.sender != owner()) revert NotHighestBidder();
 
@@ -279,6 +294,7 @@ contract Auctions is Ownable {
 
         emit Claimed(auctionId, auction.highestBidder);
 
+        //@audit Can it underflow?
         (bool success,) = payable(theFarmer).call{value: auction.highestBid - totalRewards}("");
         if (!success) revert TransferFailed();
         
@@ -511,6 +527,7 @@ contract Auctions is Ownable {
             paymentFromMsgValue = payment - balance;
         }
 
+        //@audit Can this be dossed
         if (msg.value != paymentFromMsgValue) revert InvalidValue();
 
         if (paymentFromBalance > 0) {
@@ -578,6 +595,7 @@ contract Auctions is Ownable {
         for (uint256 i; i < tokenCount; ++i) {
             uint256 tokenId = tokenMap[i];
             auctionTokens[tokenId] = false;
+            //@audit Use safeTransfer here
             erc721Contract.transferFrom(theBarn, highestBidder, tokenId);
         }
     }

--- a/src/Harvest.sol
+++ b/src/Harvest.sol
@@ -41,6 +41,7 @@ contract Harvest is Ownable {
         bidTicket = IBidTicket(bidTicket_);
     }
 
+    //@audit No check of the contract addresses
     function batchTransfer(
         TokenType[] calldata types,
         address[] calldata contracts,
@@ -63,6 +64,7 @@ contract Harvest is Ownable {
 
         for (uint256 i; i < length; ++i) {
             TokenType tokenType = types[i];
+            //@audit This doesn't look good
             address tokenContract = contracts[i] == address(0) ? currentContract : contracts[i];
             currentContract = tokenContract;
 
@@ -80,6 +82,7 @@ contract Harvest is Ownable {
                 }
                 IERC721(tokenContract).transferFrom(msg.sender, theBarn, tokenIds[i]);
             } else if (tokenType == TokenType.ERC1155) {
+                //@audit Will it revert for 0?
                 uint256 count = counts[i];
                 unchecked {
                     totalTokens += count;


### PR DESCRIPTION
## Summary
In an auction most user would want to bid at last block to avoid price hike. The `antiSnipeDuration` is in place to increase the auction duration to avoid such snipping. But at `block.timestamp = auction.endTime` all 3 methods `claim(), refund() & bid()` can be called. The outcome depends upon whose transaction is included first in the block. The rest will revert.

## Impact
If the `claim()` goes first then the auction extends but the `highestbidder` will try to frontrun and `claim()` to ensure it's win. This is giving the highestbidder an unfair advantange over others.

## Mitigation
Decide if the auction length should be = auction.endTime or < auction.endTime and do the changes accordingly.